### PR TITLE
Update export/import dialogs to handle zip file backups

### DIFF
--- a/config-editor.py
+++ b/config-editor.py
@@ -752,7 +752,7 @@ class Confix:
         self.import_json.run()
 
     def save_config(self, widget):
-        self.export_json.run()
+        self.export_json.run(to_json=True)
 
     def show_help(self, widget):
         self.arw2["help_window"].show()

--- a/confix.glade
+++ b/confix.glade
@@ -539,8 +539,8 @@ and others</property>
       </object>
     </child>
     <action-widgets>
-      <action-widget response="1">button2</action-widget>
-      <action-widget response="0">button1</action-widget>
+      <action-widget response="-5">button2</action-widget>
+      <action-widget response="-6">button1</action-widget>
     </action-widgets>
   </object>
   <object class="GtkMenu" id="chooser_proxy_groups_menu">
@@ -998,6 +998,174 @@ After clicking close, you will be shown the internet filter rule created for you
       <!-- column-name name -->
       <column type="gchararray"/>
     </columns>
+  </object>
+  <object class="GtkDialog" id="restore_config_dialog">
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">Restore Configuration</property>
+    <property name="type_hint">dialog</property>
+    <property name="deletable">False</property>
+    <child>
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="button9">
+                <property name="label">gtk-apply</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="button11">
+                <property name="label">gtk-close</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">Select the file which you wish to restore, click the options to restore and click apply</property>
+                <property name="wrap">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_left">6</property>
+                    <property name="margin_right">6</property>
+                    <property name="label" translatable="yes">Select Options to Restore:</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="homogeneous">True</property>
+                    <child>
+                      <object class="GtkCheckButton" id="restore_config_permission_check">
+                        <property name="label" translatable="yes">Permissions</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="restore_config_network_check">
+                        <property name="label" translatable="yes">Network</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="restore_config_confix_check">
+                        <property name="label" translatable="yes">Connexion Profiles</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-5">button9</action-widget>
+      <action-widget response="-6">button11</action-widget>
+    </action-widgets>
   </object>
   <object class="GtkTextBuffer" id="textbuffer1"/>
   <object class="GtkTextBuffer" id="textbuffer2"/>

--- a/confix.py
+++ b/confix.py
@@ -57,7 +57,7 @@ from firewall import Firewall
 from users import Users
 from config_profile import ConfigProfile, requires_password, test_decrypt_config, encrypt_password, DEFAULT_KEY
 from assistant import Assistant
-from json_config import ImportJsonDialog, ExportJsonDialog, ImportJsonFromIdefix, ImportJsonFromFTP
+from json_config import RestoreDialog, ExportJsonDialog, ImportJsonDialog
 
 ###########################################################################
 # CONFIGURATION ###########################################################
@@ -124,8 +124,9 @@ class Confix:
                 pass
 
         self.import_json = ImportJsonDialog(self.arw, self)
-        self.import_json_from_idefix = ImportJsonFromIdefix(self.arw, self)
-        self.import_json_from_ftp = ImportJsonFromFTP(self.arw, self)
+        # self.import_json_from_idefix = ImportJsonFromIdefix(self.arw, self)
+        # self.import_json_from_ftp = ImportJsonFromFTP(self.arw, self)
+        self.restore_dialog = RestoreDialog(self.arw, self)
         self.export_json = ExportJsonDialog(self.arw, self)
         self.offline = False
 
@@ -506,26 +507,26 @@ class Confix:
 
 
     def open_config(self, widget):
-        self.import_json.run(offline = True)
+        self.import_json.run(offline=True)
 
     def save_config(self, widget):
-        self.export_json.run(configpath = self.import_json.configpath, offline = True)
+        self.export_json.run(configpath=self.restore_dialog.configpath, offline=True, to_json=True)
 
     def save_config_as(self, widget):
-        self.export_json.run(offline = True)
+        self.export_json.run(offline=True, to_json=True)
 
     def import_config(self, widget):
-        param = widget.name.split("@")[1]
-        self.import_json.run(param)
+        self.restore_dialog.run(source='local', offline=True)
 
     def import_config_from_idefix_backup(self, widget):
-        self.import_json_from_idefix.run()
+        self.restore_dialog.run(source='idefix')
 
     def import_config_from_ftp_backup(self, widget):
-        self.import_json_from_ftp.run()
+        self.restore_dialog.run(source='ftp')
 
     def export_config(self, widget):
-        self.export_json.run()
+        offline = self.profiles.config['__options'].get('developper_menu', 0) == '1'
+        self.export_json.run(offline=offline)
 
     def show_help_colors(self, widget):
         self.arw2["help_colors_window"].show()

--- a/json_config.py
+++ b/json_config.py
@@ -1,6 +1,7 @@
 import io
 import json
 import os
+import sys
 import zipfile
 from collections import OrderedDict
 
@@ -8,7 +9,7 @@ from gi.repository import Gtk
 
 from connection_information import Information
 from ftp_client import ftp_connect, ftp_get, ftp_send
-from util import get_config_path, alert
+from util import get_config_path, alert, showwarning
 
 
 class ImportJsonDialog:
@@ -19,14 +20,9 @@ class ImportJsonDialog:
 
         self.file_filter = Gtk.FileFilter()
         self.file_filter.add_pattern('*.json')
-        self.file_filter.add_pattern('*.zip')
         self.configpath = ""
 
-    def run(self, type1='permissions', offline=False):
-        if not offline:
-            if not hasattr(self.controller, 'ftp') or not self.controller.ftp:
-                alert(_("You cannot Restore a configuration without a connexion. \nIf you want to work offline, \nuse «Open Configuration on disk...» \nin the developper menu"))
-                return
+    def run(self, offline=False):
         dialog = Gtk.FileChooserDialog(
             _("Import Config"),
             self.arw['window1'],
@@ -38,32 +34,15 @@ class ImportJsonDialog:
         response = dialog.run()
         if response == Gtk.ResponseType.ACCEPT:
             self.configpath = dialog.get_filename()
-            zf = zipfile.ZipFile(self.configpath)
-            if type1 == "permissions":
-                data1 = zf.open("idefix.json").read().decode("ascii")
-                configname = os.path.split(self.configpath)[1]
-                config = json.loads(
-                    data1,
-                    object_pairs_hook=OrderedDict
-                )
-                self.controller.config = config
-                self.controller.update()
-                self.update_gui()
-
-            elif type1 == "network":
-                # TODO : how to get rid of the Windows newlines ?
-                file1 = zf.open("idefix2_conf.json")
-                ftp1 = self.controller.ftp_config
-                ftp = ftp_connect(ftp1["server"], ftp1["login"], ftp1["pass"])
-                ftp_send(ftp, file_object=file1, dest_name="idefix2_conf.json" )
-                command_f = io.BytesIO()
-                command_f.write(bytes("restore_config", "utf-8"))
-                command_f.seek(0)
-                # send command
-                ftp.storlines('STOR trigger', command_f)
-                ftp.close()
-
-            if offline :
+            configname = os.path.split(self.configpath)[1]
+            config = json.load(
+                open(self.configpath, 'r'),
+                object_pairs_hook=OrderedDict
+            )
+            self.controller.config = config
+            self.controller.update()
+            self.update_gui()
+            if offline:
                 self.controller.offline = True
                 # close ftp connection
                 try:
@@ -74,125 +53,254 @@ class ImportJsonDialog:
                 self.controller.arw["save_button1"].set_sensitive(False)
                 self.controller.arw["save_button2"].set_sensitive(False)
                 self.controller.arw["configname"].set_text(configname)
-
-
-
         dialog.destroy()
 
     def update_gui(self):
         self.controller.maclist = self.controller.users.create_maclist()
         self.controller.users.populate_users()
         self.controller.proxy_users.populate_proxy()
-        #self.controller.populate_ports()
+        # self.controller.populate_ports()
         self.controller.populate_groups()
         self.controller.populate_users_chooser()
-        #self.controller.firewall.populate_firewall()
+        # self.controller.firewall.populate_firewall()
         self.controller.set_check_boxes()
         self.controller.set_colors()
 
 
-class ImportJsonFromIdefix:
-
+class RestoreDialog:
     def __init__(self, arw, controller):
         self.arw = arw
         self.controller = controller
+        self.configpath = ''
+        self.file_filter = Gtk.FileFilter()
+        self.file_filter.add_pattern('*.zip')
 
-    def run(self, offline = False):
+    def run(self, source='local', offline=False, type=None):
+        """ Run the restore dialog to select which files to restore. If type is specified then import those types
+        without asking the user. Type can either be a string or an array. Source can be local for local files,
+         ftp for ftp files or idefix for files on idefix"""
+
         if not offline:
             if not hasattr(self.controller, 'ftp') or not self.controller.ftp:
-                alert(_("You cannot Restore a configuration without a connexion. \nIf you want to work offline, \nuse «Open Configuration on disk...» \nin the developper menu"))
+                alert(_(
+                    "You cannot Restore a configuration without a connexion. \nIf you want to work offline, \nuse «Open Configuration on disk...» \nin the developper menu"))
                 return
 
-        # get the list of backups present in Idefix
-        x = Information.get_infos(self, "list_backups")
-        backup_list = json.loads(x)
-        backup_list.sort(reverse = True)
-        self.arw["backups_list_store"].clear()
-        for backup in backup_list:
-            self.arw["backups_list_store"].append([backup])
-        x = self.arw["backup_restore"].run()
+        self.arw['restore_config_permission_check'].set_active(False)
+        self.arw['restore_config_network_check'].set_active(False)
+        self.arw['restore_config_confix_check'].set_active(False)
 
-        if x == 1:
-            (model, node) = self.arw["backups_list_tree"].get_selection().get_selected()
-            name = model.get_value(node, 0)
-            backupfiledata = (Information.get_infos(self, "get_backup " + name, result="result.zip"))
-            backup_f = io.BytesIO()
-            backup_f.write(backupfiledata)
-            backup_f.seek(0)
-            zf = zipfile.ZipFile(backup_f)
-            config_json = zf.open("home/rock64/idefix/idefix.json").read().decode("cp850")
+        if type:
+            response = Gtk.ResponseType.OK
+            if 'permissions' in type:
+                self.arw['restore_config_permission_check'].set_active(True)
+            if 'network' in type:
+                self.arw['restore_config_network_check'].set_active(True)
+            if 'restore_config_confix_check' in type:
+                self.arw['restore_config_confix_check'].set_active(True)
 
-            config = json.loads(config_json, object_pairs_hook=OrderedDict)
-            self.controller.config = config
-            self.controller.update()
-            self.update_gui()
-
-        self.arw["backup_restore"].hide()
-
-        print("terminé")
-
-
-    def update_gui(self):
-        self.controller.maclist = self.controller.users.create_maclist()
-        self.controller.users.populate_users()
-        self.controller.proxy_users.populate_proxy()
-        #self.controller.populate_ports()
-        self.controller.populate_groups()
-        self.controller.populate_users_chooser()
-        #self.controller.firewall.populate_firewall()
-        self.controller.set_check_boxes()
-        self.controller.set_colors()
-
-
-class ImportJsonFromFTP:
-
-    def __init__(self, arw, controller):
-        self.arw = arw
-        self.controller = controller
-
-    def run(self, offline = False):
-        if not offline:
-            if not hasattr(self.controller, 'ftp') or not self.controller.ftp:
-                alert(_("You cannot Restore a configuration without a connexion. \nIf you want to work offline, \nuse «Open Configuration on disk...» \nin the developper menu"))
-                return
-
-        # get the list of backups present on the ftp server
-        # get Idefix ftp configuration
-        if self.controller.idefix_module:
-            ftp1 = json.loads(Information.get_infos(self, "ftp"))
-            ftp = ftp_connect(ftp1["ftp"], ftp1["login"], ftp1["password"], self.controller)
         else:
-            ftp1 = self.controller.ftp_config
-            ftp = ftp_connect(ftp1["server"][0], ftp1["login"][0], ftp1["pass"][0])
+            response = self.arw['restore_config_dialog'].run()
 
-        if ftp:
-            ftp.cwd("backup")
-            backup_list = ftp.nlst()
-            backup_list.sort(reverse = True)
+        if response != Gtk.ResponseType.OK:
+            self.arw['restore_config_dialog'].hide()
+            return
+
+        zf = None
+        path_prefix = ''
+
+        import_permissions = self.arw['restore_config_permission_check'].get_active()
+        import_network = self.arw['restore_config_network_check'].get_active()
+        import_confix = self.arw['restore_config_confix_check'].get_active()
+
+        if not import_confix and not import_network and not import_permissions:
+            alert(_("You must choose at least one option to restore"))
+            self.arw['restore_config_dialog'].hide()
+            return
+
+        if source == 'local':
+            # Ask the user to select a file to restore
+
+            dialog = Gtk.FileChooserDialog(
+                _("Import Config"),
+                self.arw['window1'],
+                Gtk.FileChooserAction.OPEN,
+                (_("Import"), Gtk.ResponseType.ACCEPT),
+            )
+            dialog.set_filter(self.file_filter)
+
+            response = dialog.run()
+            if response == Gtk.ResponseType.ACCEPT:
+                self.configpath = dialog.get_filename()
+                try:
+                    zf = zipfile.ZipFile(self.configpath)
+                except zipfile.BadZipFile:
+                    alert(_("Zip file could not be read"))
+                path_prefix = ''
+                dialog.destroy()
+            else:
+                dialog.destroy()
+                self.arw['restore_config_dialog'].hide()
+                return
+
+        elif source == 'ftp':
+            # get the list of backups present on the ftp server
+            # get Idefix ftp configuration
+
+            if self.controller.idefix_module:
+                ftp1 = json.loads(Information.get_infos(self, "ftp"))
+                ftp = ftp_connect(ftp1["ftp"], ftp1["login"], ftp1["password"], self.controller)
+            else:
+                ftp1 = self.controller.ftp_config
+                ftp = ftp_connect(ftp1["server"][0], ftp1["login"][0], ftp1["pass"][0])
+
+            if ftp:
+                ftp.cwd("backup")
+                backup_list = ftp.nlst()
+                backup_list.sort(reverse=True)
+                self.arw["backups_list_store"].clear()
+                for backup in backup_list:
+                    self.arw["backups_list_store"].append([backup])
+                response = self.arw["backup_restore"].run()
+            else:
+                alert(_("Could not get FTP connection"))
+                response = Gtk.ResponseType.CANCEL
+
+            if response == Gtk.ResponseType.OK:
+                (model, node) = self.arw["backups_list_tree"].get_selection().get_selected()
+                name = model.get_value(node, 0)
+                backupfiledata = (ftp_get(ftp, name))
+                backup_f = io.BytesIO()
+                backup_f.write(backupfiledata)
+                backup_f.seek(0)
+                try:
+                    zf = zipfile.ZipFile(backup_f)
+                except zipfile.BadZipFile:
+                    alert(_("Zip file could not be read"))
+
+                path_prefix = 'home/rock64/idefix/'
+                self.arw["backup_restore"].hide()
+            else:
+                self.arw["backup_restore"].hide()
+                self.arw['restore_config_dialog'].hide()
+                return
+
+        elif source == 'idefix':
+            # get the list of backups present in Idefix
+
+            x = Information.get_infos(self, "list_backups")
+            backup_list = json.loads(x)
+            backup_list.sort(reverse=True)
+
             self.arw["backups_list_store"].clear()
+
             for backup in backup_list:
                 self.arw["backups_list_store"].append([backup])
-            x = self.arw["backup_restore"].run()
+            response = self.arw["backup_restore"].run()
 
-        if x == 1:
-            (model, node) = self.arw["backups_list_tree"].get_selection().get_selected()
-            name = model.get_value(node, 0)
-            backupfiledata = (ftp_get(ftp, name))
-            backup_f = io.BytesIO()
-            backup_f.write(backupfiledata)
-            backup_f.seek(0)
-            zf = zipfile.ZipFile(backup_f)
-            config_json = zf.open("home/rock64/idefix/idefix.json").read().decode("cp850")
+            if response == Gtk.ResponseType.OK:
+                (model, node) = self.arw["backups_list_tree"].get_selection().get_selected()
+                name = model.get_value(node, 0)
 
-            config = json.loads(config_json, object_pairs_hook=OrderedDict)
-            self.controller.config = config
-            self.controller.update()
-            self.update_gui()
+                backupfiledata = (Information.get_infos(self, "get_backup " + name, result="result.zip"))
+                backup_f = io.BytesIO()
+                backup_f.write(backupfiledata)
+                backup_f.seek(0)
+                try:
+                    zf = zipfile.ZipFile(backup_f)
+                except zipfile.BadZipFile as e:
+                    alert(_("Zip file could not be read"))
+                path_prefix = 'home/rock64/idefix/'
+                self.arw["backup_restore"].hide()
+            else:
+                self.arw["backup_restore"].hide()
+                self.arw['restore_config_dialog'].hide()
+                return
+        else:
+            self.arw["backup_restore"].hide()
+            self.arw['restore_config_dialog'].hide()
+            return
 
-        self.arw["backup_restore"].hide()
+        if not zf:
+            self.arw['restore_config_dialog'].hide()
+            return
 
-        print("terminé")
+        skip_confix = ''
+        skip_network = ''
+        skip_permissions = ''
 
+        if import_permissions:
+            try:
+                data1 = zf.open(path_prefix + "idefix.json").read().decode("cp850")
+            except KeyError:
+                skip_permissions = _("Permissions file does not exist in backup")
+            else:
+                config = json.loads(
+                    data1,
+                    object_pairs_hook=OrderedDict
+                )
+                self.controller.config = config
+
+        if import_network:
+            try:
+                data1 = zf.open(path_prefix + "idefix2_conf.json").read().decode("cp850").replace('\r\n', '\n')
+            except KeyError:
+                skip_network = _("Network file does not exist in backup")
+            else:
+                ftp1 = self.controller.ftp_config
+                ftp = ftp_connect(ftp1["server"], ftp1["login"], ftp1["pass"])
+                tmp_file = get_config_path('tmp_idefix2_conf.json')
+                with open(tmp_file, 'w') as f:
+                    f.write(data1)
+                ftp_send(ftp, filepath=tmp_file, dest_name="idefix2_conf.json")
+                command_f = io.BytesIO()
+                command_f.write(bytes("restore_config", "utf-8"))
+                command_f.seek(0)
+                # send command
+                ftp.storlines('STOR trigger', command_f)
+                ftp.close()
+                os.unlink(tmp_file)
+
+        if import_confix:
+            try:
+                data1 = zf.open(path_prefix + "confix.cfg").read().decode("cp850")
+            except KeyError:
+                skip_confix = _("Connections file not exist in backup")
+            else:
+                with open(self.controller.profiles.filename, 'w') as f:
+                    f.write(data1)
+
+        self.controller.update()
+        self.update_gui()
+
+        if skip_permissions or skip_network or skip_confix:
+            msg = ''
+            if skip_permissions:
+                msg += skip_permissions + '\n'
+            if skip_network:
+                msg += skip_network + '\n'
+            if skip_confix:
+                msg += skip_confix + '\n'
+
+            showwarning(_("Some files were not restored"), msg)
+
+        if offline:
+            configname = os.path.split(self.configpath)[1]
+            self.controller.offline = True
+            # close ftp connection
+            try:
+                self.controller.ftp.close()
+            except:
+                pass
+            # disable the save button
+            self.controller.arw["save_button1"].set_sensitive(False)
+            self.controller.arw["save_button2"].set_sensitive(False)
+            self.controller.arw["configname"].set_text(configname)
+
+        self.arw['restore_config_dialog'].hide()
+        if import_confix and not skip_confix:
+            alert(_("Please restart Confix to use your restored profiles"))
+            sys.exit(1)
 
     def update_gui(self):
         self.controller.maclist = self.controller.users.create_maclist()
@@ -211,10 +319,9 @@ class ExportJsonDialog:
         self.arw = arw
         self.controller = controller
 
-        self.file_filter = Gtk.FileFilter()
-        self.file_filter.add_pattern('*.json')
+    def run(self, configpath=None, offline=False, to_json=False):
+        """Export the configuration either as a zip file if to_json=False or as a json file if to_json=True"""
 
-    def run(self, configpath = None, offline = False):
         if not configpath:
             dialog = Gtk.FileChooserDialog(
                 _("Export Config"),
@@ -222,26 +329,39 @@ class ExportJsonDialog:
                 Gtk.FileChooserAction.SAVE,
                 (_("Export"), Gtk.ResponseType.ACCEPT),
             )
-            dialog.set_filter(self.file_filter)
+            file_filter = Gtk.FileFilter()
+            if to_json:
+                file_filter.add_pattern('*.json')
+            else:
+                file_filter.add_pattern('*.zip')
+            dialog.set_filter(file_filter)
 
             response = dialog.run()
             if response == Gtk.ResponseType.ACCEPT:
-                configpath =    dialog.get_filename()
+                configpath = dialog.get_filename()
             dialog.destroy()
 
-##        f1 = open(configpath, "w", newline = "\n")
         config2 = self.controller.rebuild_config()
-        config2_str = json.dumps(config2, indent = 3)
-##        f1.write(config2_str)
-##        f1.close()
+        config2_str = json.dumps(config2, indent=3)
 
+        if to_json:
+            f1 = open(configpath, "w", newline="\n")
+            f1.write(config2_str)
+            f1.close()
+        else:
+            zf = zipfile.ZipFile(os.path.splitext(configpath)[0] + ".zip", 'w')
+            try:
+                x = Information.get_infos(self, "get_conf")
+                conf_list = json.loads(x)
+                zf.writestr("idefix2_conf.json", conf_list["idefix2_conf.json"])
+            except TypeError:
+                if offline:
+                    print("No connection, skipping idefix2_conf.json")
+                else:
+                    alert(_("Cannot retrieve network configuration from Idefix"))
+                    return
 
-        # temporary code to be improved. We save here the three configuration files
-        zf = zipfile.ZipFile(os.path.splitext(configpath)[0] + ".zip", 'w')
-        x = Information.get_infos(self, "get_conf")
-        conf_list = json.loads(x)
-        zf.writestr("idefix2_conf.json", conf_list["idefix2_conf.json"])
-        zf.writestr("idefix.json", config2_str)
-        zf.write(get_config_path('confix.cfg'), 'confix.cfg')
-        zf.close()
+            zf.writestr("idefix.json", config2_str)
+            zf.write(get_config_path('confix.cfg'), 'confix.cfg')
+            zf.close()
         alert(_("Configuration saved"))


### PR DESCRIPTION
Add a choice of which file to import on loading a zip file
Make sure developer dialog uses the original json format
Make the zip file export all the configuration options